### PR TITLE
docs: fix service binary path in manual installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,8 @@ cd BlueVein
 cargo build --release
 
 # 2. Install
-sudo cp target/release/bluevein /usr/local/bin/
+sudo cp target/release/bluevein /usr/bin/
 sudo cp ./systemd/bluevein.service /etc/systemd/system/
-
-# Fix binary path in service file (points to /usr/bin by default)
-sudo sed -i 's|/usr/bin/bluevein|/usr/local/bin/bluevein|g' /etc/systemd/system/bluevein.service
 
 # 3. Run
 sudo systemctl daemon-reload

--- a/README.ru.md
+++ b/README.ru.md
@@ -113,11 +113,8 @@ cd BlueVein
 cargo build --release
 
 # 2. Устанавливаем
-sudo cp target/release/bluevein /usr/local/bin/
+sudo cp target/release/bluevein /usr/bin/
 sudo cp ./systemd/bluevein.service /etc/systemd/system/
-
-# Исправляем путь в файле службы (по умолчанию указывает на /usr/bin)
-sudo sed -i 's|/usr/bin/bluevein|/usr/local/bin/bluevein|g' /etc/systemd/system/bluevein.service
 
 # 3. Запускаем
 sudo systemctl daemon-reload


### PR DESCRIPTION
### Description
The current manual installation instructions guide the user to copy the binary to `/usr/local/bin/`. However, the provided `systemd/bluevein.service` file is configured with `ExecStart=/usr/bin/bluevein` (likely intended for package managers/AUR).

This causes the service to fail silently when installed manually because it cannot find the executable.

### Changes
I have updated `README.md` (both in the English and Russian sections) to include a `sed` command during the installation process.

This command automatically updates the `ExecStart` path in the service file to point to `/usr/local/bin/` (where the binary is actually copied), ensuring the service starts correctly out-of-the-box for manual users without breaking the default configuration for package maintainers.