### PR TITLE
docs: Correct the Windows EFI device path format

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,24 +227,23 @@ Get-Service BlueVeinService
 > By default, BlueVein automatically detects the EFI partition. To specify a particular device, use the `BLUEVEIN_EFI_DEVICE` environment variable:
 > ```powershell
 > # For manual launch
-> $env:BLUEVEIN_EFI_DEVICE="\\.\PhysicalDrive0"
+> $env:BLUEVEIN_EFI_DEVICE="\\?\Volume{GUID}\"
 > .\bluevein.exe
 >
 > # To set machine-wide environment variable for the service
-> [System.Environment]::SetEnvironmentVariable('BLUEVEIN_EFI_DEVICE', '\\.\PhysicalDrive0', 'Machine')
+> [System.Environment]::SetEnvironmentVariable('BLUEVEIN_EFI_DEVICE', '\\?\Volume{GUID}\', 'Machine')
 > .\bluevein.exe install
 > .\bluevein.exe start
 > ```
 >
 > **Windows device format:**
-> - `\\.\PhysicalDrive0` — Physical disk (most common)
-> - `\\.\Harddisk0Partition1` — Specific partition
 > - `\\?\Volume{GUID}\` — Volume GUID path
 >
 > **How to find your EFI device:**
 > ```powershell
 > # List all partitions and find EFI
-> Get-Partition | Where-Object {$_.GptType -eq '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'}
+> Get-Partition | Where-Object {$_.GptType -eq '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'} | Get-Volume | Select-Object DriveLetter, FileSystemLabel, FileSystemType, DriveType, HealthStatus, OperationalStatus, SizeRemaining, Size, UniqueId
+> # or simply: mountvol
 > ```
 
 ## ⌨️ Service Management

--- a/README.ru.md
+++ b/README.ru.md
@@ -234,24 +234,23 @@ Get-Service BlueVeinService
 > По умолчанию BlueVein автоматически определяет EFI-раздел. Для указания конкретного устройства используйте переменную окружения `BLUEVEIN_EFI_DEVICE`:
 > ```powershell
 > # Для ручного запуска
-> $env:BLUEVEIN_EFI_DEVICE="\\.\PhysicalDrive0"
+> $env:BLUEVEIN_EFI_DEVICE="\\?\Volume{GUID}\"
 > .\bluevein.exe
 >
 > # Для установки сервиса с переменной окружения
-> [System.Environment]::SetEnvironmentVariable('BLUEVEIN_EFI_DEVICE', '\\.\PhysicalDrive0', 'Machine')
+> [System.Environment]::SetEnvironmentVariable('BLUEVEIN_EFI_DEVICE', '\\?\Volume{GUID}\', 'Machine')
 > .\bluevein.exe install
 > .\bluevein.exe start
 > ```
 >
 > **Формат устройства Windows:**
-> - `\\.\PhysicalDrive0` — Физический диск (наиболее частый случай)
-> - `\\.\Harddisk0Partition1` — Конкретный раздел
 > - `\\?\Volume{GUID}\` — Путь через GUID тома
 >
 > **Как найти своё EFI-устройство:**
 > ```powershell
-> # Список всех разделов и поиск EFI
-> Get-Partition | Where-Object {$_.GptType -eq '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'}
+> # List all partitions and find EFI
+> Get-Partition | Where-Object {$_.GptType -eq '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'} | Get-Volume | Select-Object DriveLetter, FileSystemLabel, FileSystemType, DriveType, HealthStatus, OperationalStatus, SizeRemaining, Size, UniqueId
+> # or simply: mountvol
 > ```
 
 ## ⌨️ Управление сервисом

--- a/README.ru.md
+++ b/README.ru.md
@@ -248,7 +248,7 @@ Get-Service BlueVeinService
 >
 > **Как найти своё EFI-устройство:**
 > ```powershell
-> # List all partitions and find EFI
+> # Вывести список всех разделов и найти EFI
 > Get-Partition | Where-Object {$_.GptType -eq '{c12a7328-f81f-11d2-ba4b-00a0c93ec93b}'} | Get-Volume | Select-Object DriveLetter, FileSystemLabel, FileSystemType, DriveType, HealthStatus, OperationalStatus, SizeRemaining, Size, UniqueId
 > # or simply: mountvol
 > ```


### PR DESCRIPTION
Fixes #14. By the way, I find that Specific partitions such as `\\.\Harddisk0Partition1` can be opened, but file writes fail with the current Windows path handling.

## Summary

- Update the `BLUEVEIN_EFI_DEVICE` examples to use a Windows volume GUID path (`\\?
\Volume{GUID}\`).
- Remove unsupported physical disk and partition path examples.
- Keep the English and Russian documentation consistent.

## Motivation

`BLUEVEIN_EFI_DEVICE` expects the EFI volume to be specified using a volume GUID path. The previous examples could mislead Windows users into providing an incorrect device path.

## Testing

Documentation-only change. Verified that both README files use the same path format.