### PR TITLE
fix: use BTHPORT for LE keys on Windows 10/11

### DIFF
--- a/src/windows/bluetooth.rs
+++ b/src/windows/bluetooth.rs
@@ -10,7 +10,7 @@ use winreg::enums::*;
 use winreg::RegKey;
 
 const BLUETOOTH_REG_PATH: &str = r"SYSTEM\CurrentControlSet\Services\BTHPORT\Parameters\Keys";
-const BLUETOOTH_LE_REG_PATH: &str = r"SYSTEM\CurrentControlSet\Services\BTHLE\Parameters\Keys";
+const BLUETOOTH_LE_REG_PATH: &str = r"SYSTEM\CurrentControlSet\Services\BTHPORT\Parameters\Keys";
 
 pub struct WindowsBluetoothManager {
     hklm: RegKey,


### PR DESCRIPTION
## Fix: LE (BLE) devices not synced on Windows 10/11

### Problem

BlueVein reads LE (Bluetooth Low Energy) pairing keys from `BTHLE\Parameters\Keys`, but **this registry path does not exist on Windows 10/11**. LE device keys (LTK/IRK/CSRK) are stored under `BTHPORT\Parameters\Keys\<adapter>\<device>` (as subkeys), the same path as Classic link keys.

As a result, **all BLE devices are invisible to BlueVein** — only Classic devices get synced. This affects the majority of modern Bluetooth peripherals:

- Logitech K780, MX Master, M720 Triathlon (keyboards/mice)
- AirPods, Sony WH-1000XM, Bose headphones
- Xbox/PS5 controllers
- Any BLE-only device

### Root Cause

```rust
// Before (wrong on Win 10/11):
const BLUETOOTH_LE_REG_PATH: &str = r"SYSTEM\CurrentControlSet\Services\BTHLE\Parameters\Keys";

// After (correct):
const BLUETOOTH_LE_REG_PATH: &str = r"SYSTEM\CurrentControlSet\Services\BTHPORT\Parameters\Keys";
```

The `BTHLE` service key is not created by the Windows 10/11 Bluetooth stack. LE pairing keys are stored as **subkeys** under `BTHPORT\Parameters\Keys\<adapter>\<device>` (Classic keys are stored as **values** under the same adapter key). The existing read/write logic already handles both formats correctly — only the path constant was wrong.

### Verification

Tested on **Windows 11 Pro (build 26200)** with **Logitech K780** and **M720 Triathlon** (both BLE):

| Metric | Before fix | After fix |
|--------|-----------|-----------|
| Devices found | 7 (Classic only) | **10** (7 Classic + 4 LE) |
| K780 LE keys (LTK/IRK/CSRK) | ❌ Not captured | ✅ Captured |
| M720 LE keys (LTK/IRK/CSRK) | ❌ Not captured | ✅ Captured |
| `bluevein.json` on ESP | Classic keys only | Classic + LE keys |

Confirmed via SYSTEM-context registry export that `BTHPORT\Parameters\Keys\289529fa6cf1` contains:
- 7 Classic devices as **values** (link keys)
- 4 LE devices as **subkeys** (with LTK, IRK, CSRK, EDIV, ERand, AddressType values)

### Impact

This is a **critical bug** for all Windows 10/11 users — BLE devices are the most common Bluetooth peripherals today. Without this fix, BlueVein cannot sync any LE device, making it useless for the primary use case (dual-boot keyboard/mouse/headphone sharing).
