### PR TITLE
fix: truncate trailing cluster garbage from fat32-raw read_file output

### DIFF
--- a/src/efi.rs
+++ b/src/efi.rs
@@ -112,6 +112,36 @@ fn find_mounted_efi() -> Option<String> {
     None
 }
 
+fn find_json_end(data: &[u8]) -> usize {
+    let (mut depth, mut in_str, mut esc) = (0u32, false, false);
+    for (i, &b) in data.iter().enumerate() {
+        if esc {
+            esc = false;
+            continue;
+        }
+        if in_str {
+            match b {
+                b'"' => in_str = false,
+                b'\\' => esc = true,
+                _ => {}
+            }
+        } else {
+            match b {
+                b'{' | b'[' => depth += 1,
+                b'}' | b']' if depth > 0 => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return i + 1;
+                    }
+                }
+                b'"' => in_str = true,
+                _ => {}
+            }
+        }
+    }
+    data.len()
+}
+
 /// Read BlueVein configuration from EFI partition using default device
 #[allow(dead_code)]
 pub fn read_config() -> Result<BlueVeinConfig, EfiError> {
@@ -161,7 +191,12 @@ pub fn read_config_with_device(device: Option<&str>) -> Result<BlueVeinConfig, E
     .ok_or_else(|| EfiError::ReadError("ESP partition not found".to_string()))?;
 
     match volume.read_file(CONFIG_FILENAME) {
-        Ok(Some(data)) => {
+        Ok(Some(mut data)) => {
+            let end = find_json_end(&data);
+            if end < data.len() {
+                log!("[BlueVein] Truncated {} trailing bytes from config", data.len() - end);
+                data.truncate(end);
+            }
             let json_str = String::from_utf8(data).map_err(|e| {
                 EfiError::ParseError(format!("Invalid UTF-8 in config file: {}", e))
             })?;


### PR DESCRIPTION
## Problem

Reading `bluevein.json` from the ESP partition via `fat32-raw` crate's
`read_file` returns trailing garbage beyond the actual JSON content:

>Error checking EFI changes: Failed to parse config:
>Invalid UTF-8 in config file: invalid utf-8 sequence of 1 bytes from index 1025

The root cause is that the crate's cluster chain traversal does not correctly
respect the file size recorded in the FAT directory entry, causing entire
clusters to be read past the end of the file. For a 2-byte file (`{}`), the
resulting buffer is 4096+ bytes with garbage appended.

## Fix

Added `find_json_end()` — a bracket-depth-aware scanner that walks the raw
bytes, tracks `{}`/`[]` nesting depth, and correctly skips quoted strings
and escape sequences. It returns the byte offset of the real JSON boundary.

`read_config_with_device` now calls `find_json_end()` on the output of
`read_file` and truncates trailing garbage before UTF-8 decoding and JSON
parsing.

## Why this approach

- Works regardless of what garbage the crate appends (zeros, stale data, etc.)
- Correctly skips `{}` and `[]` inside JSON string values
- Minimal change: ~20 lines, no new dependencies
- Defensive measure that also guards against other potential upstream quirks